### PR TITLE
Get ArangoDB credentials from a run time mounted secret object

### DIFF
--- a/cmd/topology/topology.go
+++ b/cmd/topology/topology.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/base64"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"runtime"
@@ -18,6 +20,17 @@ import (
 
 	"net/http"
 	_ "net/http/pprof"
+)
+
+const (
+	// userFile defines the name of file containing base64 encoded user name
+	userFile = "./.username"
+	// passFile defines the name of file containing base64 encoded password
+	passFile = "./.password"
+	// MAXUSERNAME defines maximum length of ArangoDB user name
+	MAXUSERNAME = 256
+	// MAXPASS defines maximum length of ArangoDB password
+	MAXPASS = 256
 )
 
 var (
@@ -77,7 +90,7 @@ func main() {
 	var err error
 	isNotify, err := strconv.ParseBool(notifyEvent)
 	if err != nil {
-		glog.Errorf("invalid mock-database parameter: %s", mockDB)
+		glog.Errorf("invalid value of \"--notify-event\" parameter: %s", notifyEvent)
 		os.Exit(1)
 	}
 	var notifier kafkanotifier.Event
@@ -92,17 +105,24 @@ func main() {
 	// Initializing databse client
 	isMockDB, err := strconv.ParseBool(mockDB)
 	if err != nil {
-		glog.Errorf("invalid mock-database parameter: %s", mockDB)
+		glog.Errorf("invalid value of \"--mock-database\" parameter: %s", mockDB)
 		os.Exit(1)
 	}
 	if !isMockDB {
+		// validateDBCreds check if the user name and the password are provided either as
+		// command line parameters or via files. If both are provided command line parameters
+		// will be used, if neither, topology will fail.
+		if err := validateDBCreds(); err != nil {
+			glog.Errorf("failed to validate the database credentials with error: %+v", err)
+			os.Exit(1)
+		}
 		dbSrv, err = arangodb.NewDBSrvClient(dbSrvAddr, dbUser, dbPass, dbName, notifier)
 		if err != nil {
 			glog.Errorf("failed to initialize databse client with error: %+v", err)
 			os.Exit(1)
 		}
 	} else {
-		dbSrv, _ = mockdb.NewDBSrvClient("")
+		dbSrv, _ = mockdb.NewDBSrvClient()
 	}
 
 	if err := dbSrv.Start(); err != nil {
@@ -138,4 +158,47 @@ func main() {
 	dbSrv.Stop()
 
 	os.Exit(0)
+}
+
+func validateDBCreds() error {
+	// Attempting to access username and password files.
+	u, err := readAndDecode(userFile, MAXUSERNAME)
+	if err != nil {
+		if dbUser != "" && dbPass != "" {
+			return nil
+		}
+		return fmt.Errorf("failed to access %s with error: %+v and no username and password provided via command line arguments", userFile, err)
+	}
+	p, err := readAndDecode(passFile, MAXUSERNAME)
+	if err != nil {
+		if dbUser != "" && dbPass != "" {
+			return nil
+		}
+		return fmt.Errorf("failed to access %s with error: %+v and no username and password provided via command line arguments", passFile, err)
+	}
+	dbUser, dbPass = u, p
+
+	return nil
+}
+
+func readAndDecode(fn string, max int) (string, error) {
+	f, err := os.Open(fn)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	b := make([]byte, max)
+	n, err := io.ReadFull(f, b)
+	if err != nil {
+		return "", err
+	}
+	b = b[:n]
+	db := make([]byte, max)
+	n, err = base64.StdEncoding.Decode(db, b)
+	if err != nil {
+		return "", err
+	}
+	db = db[:n]
+
+	return string(db), nil
 }

--- a/deployment/topology.yaml
+++ b/deployment/topology.yaml
@@ -1,5 +1,13 @@
 ---
 apiVersion: v1
+kind: Secret
+metadata:
+  name: jalapeno
+data:
+  username: cm9vdA==
+  password: amFsYXBlbm8=
+---
+apiVersion: v1
 kind: Service
 spec:
   ports:
@@ -44,10 +52,10 @@ spec:
             - "http://arangodb:28529"
             - --database-name
             - "jalapeno"
-            - --database-user
-            - "root"
-            - --database-pass
-            - "jalapeno"
+            #            - --database-user
+            #            - "root"
+            #            - --database-pass
+            #            - "jalapeno"
             - --notify-event
             - "true"
           image: docker.io/sbezverk/topology:latest
@@ -60,6 +68,13 @@ spec:
             - containerPort: 56768
               protocol: TCP
               name: perf
+          volumeMounts:
+            - name: credentials
+              mountPath: /credentials
+      volumes:
+        - name: credentials
+          secret:
+            secretName: jalapeno
 metadata:
   name: topology
   namespace: default

--- a/deployment/topology.yaml
+++ b/deployment/topology.yaml
@@ -4,8 +4,8 @@ kind: Secret
 metadata:
   name: jalapeno
 data:
-  username: cm9vdA==
-  password: amFsYXBlbm8=
+  .username: cm9vdA==
+  .password: amFsYXBlbm8=
 ---
 apiVersion: v1
 kind: Service
@@ -58,7 +58,7 @@ spec:
             #            - "jalapeno"
             - --notify-event
             - "true"
-          image: docker.io/sbezverk/topology:latest
+          image: docker.io/sbezverk/topology:creds
           imagePullPolicy: Always
           name: topology
           ports:

--- a/deployment/topology.yaml
+++ b/deployment/topology.yaml
@@ -7,27 +7,6 @@ data:
   .username: cm9vdA==
   .password: amFsYXBlbm8=
 ---
-apiVersion: v1
-kind: Service
-spec:
-  ports:
-    - name: perf
-      port: 56768
-      protocol: TCP
-      targetPort: 56768
-    - name: stats
-      port: 56769
-      protocol: TCP
-      targetPort: 56769
-  selector:
-    app: topology
-  type: ClusterIP
-  externalIPs:
-    - 10.1.1.100
-metadata:
-  name: topology
-  namespace: default
----
 apiVersion: apps/v1
 kind: Deployment
 spec:
@@ -52,10 +31,12 @@ spec:
             - "http://arangodb:28529"
             - --database-name
             - "jalapeno"
+            # To override ArangoDB credentials extracted from the pod mounted secret,
+            # use the following command line parameters.
             #            - --database-user
-            #            - "root"
+            #            - ""
             #            - --database-pass
-            #            - "jalapeno"
+            #            - ""
             - --notify-event
             - "true"
           image: docker.io/sbezverk/topology:creds

--- a/pkg/arangodb/collection.go
+++ b/pkg/arangodb/collection.go
@@ -70,7 +70,7 @@ func (c *collection) processError(r *result) bool {
 }
 
 var (
-	bacllogCheckInterval = time.Millisecond * 500
+	backlogCheckInterval = time.Millisecond * 500
 )
 
 func (c *collection) genericHandler() {
@@ -84,11 +84,11 @@ func (c *collection) genericHandler() {
 	// conflicting database changes, each go routine processes a message with the unique key.
 	tokens := make(chan struct{}, concurrentWorkers)
 	done := make(chan *result, concurrentWorkers*2)
-	backlogTicker := time.NewTicker(bacllogCheckInterval)
+	backlogTicker := time.NewTicker(backlogCheckInterval)
 	for {
 		select {
 		case m := <-c.queue:
-			backlogTicker.Reset(bacllogCheckInterval)
+			backlogTicker.Reset(backlogCheckInterval)
 			o, err := newDBRecord(m.msgData, c.collectionType)
 			if err != nil {
 				glog.Errorf("failed to unmarshal message of type %d with error: %+v", c.collectionType, err)
@@ -112,7 +112,7 @@ func (c *collection) genericHandler() {
 			keyStore[k] = true
 			go c.genericWorker(k, o, done, tokens)
 		case r := <-done:
-			backlogTicker.Reset(bacllogCheckInterval)
+			backlogTicker.Reset(backlogCheckInterval)
 			if r.err != nil {
 				// Error was encountered during processing of the key, attempting to correct the error condition
 				// and pushing failed DBObject to the backlog queue

--- a/pkg/mockdb/mockdb.go
+++ b/pkg/mockdb/mockdb.go
@@ -12,7 +12,7 @@ type mockDB struct {
 }
 
 // NewDBSrvClient returns an instance of a mock DB server client process
-func NewDBSrvClient(addr string) (dbclient.Srv, error) {
+func NewDBSrvClient() (dbclient.Srv, error) {
 	m := &mockDB{
 		stop: make(chan struct{}),
 	}


### PR DESCRIPTION
This PR removes a requirement to provide ArangoDB credentials as a part of topology yaml file. 